### PR TITLE
chromebook friendly version commented out lines

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/VisionIOPhotonVisionSim.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOPhotonVisionSim.java
@@ -44,6 +44,22 @@ public class VisionIOPhotonVisionSim extends VisionIOPhotonVision {
     var cameraProperties = new SimCameraProperties();
     cameraSim = new PhotonCameraSim(camera, cameraProperties, aprilTagLayout);
     visionSim.addCamera(cameraSim, robotToCamera);
+
+    /*
+     * Chromebook/low-performance-friendly version:
+     * PhotonVision by default renders two simulated camera streams of the tags using OpenCV.
+     * This can be slow on low-resource devices like Chromebooks.
+     * The following lines replace the default simulation with a lightweight version
+     * that disables the rendered OpenCV streams but still simulates tag detection.
+     *
+     * Uncomment these lines to use the optimized version of the above code:
+     *
+     * // var cameraProperties = new SimCameraProperties();
+     * // cameraProperties.enableSimulatedImage = false; // disables OpenCV render stream
+     * // cameraSim = new PhotonCameraSim(camera, cameraProperties, aprilTagLayout);
+     *
+     * Use/application: So that sim can run properly without error spam in terminal.
+     */
   }
 
   @Override


### PR DESCRIPTION
This pull request adds documentation and code comments to help users run the vision simulation more efficiently on low-performance devices, such as Chromebooks. It explains how to disable the OpenCV-rendered camera streams in the PhotonVision simulation to reduce resource usage while still simulating tag detection.

Simulation performance improvements:

* Added detailed comments in `VisionIOPhotonVisionSim.java` explaining how to configure `SimCameraProperties` to disable OpenCV-rendered streams, making the simulation more suitable for Chromebooks and low-resource devices.